### PR TITLE
Add incident timeline and mocked playbook actions with audit logs

### DIFF
--- a/dashboard/src/api/admin.ts
+++ b/dashboard/src/api/admin.ts
@@ -167,6 +167,11 @@ export const adminApi = {
     return data.incident;
   },
 
+  runIncidentAction: async (id: string, action: string, target?: string): Promise<Incident> => {
+    const { data } = await apiClient.post(`/admin/incidents/${id}/actions`, { action, target });
+    return data.incident;
+  },
+
   updateIncident: async (id: string, updates: Partial<Incident>): Promise<Incident> => {
     const { data } = await apiClient.patch(`/admin/incidents/${id}`, updates);
     return data.incident;

--- a/dashboard/src/pages/Incidents.tsx
+++ b/dashboard/src/pages/Incidents.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect } from 'react';
 import { Layout } from '../components/Layout';
 import { MetricCard } from '../components/MetricCard';
 import { adminApi } from '../api/admin';
-import type { Incident, IncidentStatistics, IncidentStatus, IncidentSeverity, IncidentType } from '../types';
+import type { Incident, IncidentStatistics, IncidentStatus, IncidentSeverity, IncidentType, IncidentTimelineEntry, IncidentTimelineEntryType } from '../types';
 import { format, formatDistanceToNow } from 'date-fns';
 
 const severityColors: Record<IncidentSeverity, { bg: string; text: string; badge: string }> = {
@@ -25,6 +25,84 @@ const statusColors: Record<IncidentStatus, { bg: string; text: string }> = {
   closed: { bg: '#e5e7eb', text: '#374151' },
 };
 
+const timelineTypeStyles: Record<IncidentTimelineEntryType, { label: string; bg: string; text: string; border: string }> = {
+  note: { label: 'Note', bg: '#e0f2fe', text: '#0369a1', border: '#7dd3fc' },
+  status_change: { label: 'Status', bg: '#fef9c3', text: '#92400e', border: '#facc15' },
+  assignment: { label: 'Assignment', bg: '#ede9fe', text: '#6d28d9', border: '#c4b5fd' },
+  action: { label: 'Action', bg: '#dcfce7', text: '#166534', border: '#86efac' },
+};
+
+const playbookActions = [
+  {
+    key: 'disable_user',
+    label: 'Disable user',
+    description: 'Suspend account access and revoke active sessions.',
+    promptLabel: 'User or email',
+  },
+  {
+    key: 'block_ip',
+    label: 'Block IP',
+    description: 'Add the IP address to the block list.',
+    promptLabel: 'IP address',
+  },
+  {
+    key: 'open_ticket',
+    label: 'Open ticket',
+    description: 'Create a follow-up ticket in the tracking system.',
+    promptLabel: 'Ticket reference',
+  },
+];
+
+const normalizeNoteToTimeline = (content: string): { type: IncidentTimelineEntryType; metadata?: Record<string, unknown> } => {
+  if (content.startsWith('Status changed to ')) {
+    return {
+      type: 'status_change',
+      metadata: {
+        status: content.replace('Status changed to ', ''),
+      },
+    };
+  }
+  if (content.startsWith('Assigned to ')) {
+    return {
+      type: 'assignment',
+      metadata: {
+        assignedTo: content.replace('Assigned to ', ''),
+      },
+    };
+  }
+  return { type: 'note' };
+};
+
+const buildTimelineEntries = (incident: Incident): IncidentTimelineEntry[] => {
+  if (incident.timeline?.length) {
+    return [...incident.timeline].sort((a, b) => a.timestamp - b.timestamp);
+  }
+
+  const fallback: IncidentTimelineEntry[] = [
+    {
+      id: `created-${incident.id}`,
+      type: 'note',
+      timestamp: incident.createdAt,
+      actor: incident.reportedBy || 'system',
+      summary: 'Incident created',
+    },
+  ];
+
+  incident.notes.forEach((note, idx) => {
+    const normalized = normalizeNoteToTimeline(note.content);
+    fallback.push({
+      id: `note-${incident.id}-${idx}`,
+      type: normalized.type,
+      timestamp: note.timestamp,
+      actor: note.author,
+      summary: note.content,
+      metadata: normalized.metadata,
+    });
+  });
+
+  return fallback.sort((a, b) => a.timestamp - b.timestamp);
+};
+
 export function Incidents() {
   const [incidents, setIncidents] = useState<Incident[]>([]);
   const [statistics, setStatistics] = useState<IncidentStatistics | null>(null);
@@ -34,6 +112,7 @@ export function Incidents() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [filterStatus, setFilterStatus] = useState<IncidentStatus | 'all'>('all');
   const [filterSeverity, setFilterSeverity] = useState<IncidentSeverity | 'all'>('all');
+  const [actionInProgress, setActionInProgress] = useState<string | null>(null);
 
   useEffect(() => {
     fetchData();
@@ -104,12 +183,33 @@ export function Incidents() {
     }
   };
 
+  const handlePlaybookAction = async (id: string, action: typeof playbookActions[number]) => {
+    const target = action.promptLabel ? prompt(`${action.promptLabel}:`) : '';
+    if (action.promptLabel && !target) return;
+
+    try {
+      setActionInProgress(action.key);
+      await adminApi.runIncidentAction(id, action.key, target || undefined);
+      await fetchData();
+      if (selectedIncident?.id === id) {
+        const updated = await adminApi.getIncident(id);
+        setSelectedIncident(updated);
+      }
+    } catch (err: any) {
+      alert('Failed to execute playbook action: ' + err.message);
+    } finally {
+      setActionInProgress(null);
+    }
+  };
+
   const formatDuration = (ms: number): string => {
     if (ms < 60000) return `${Math.round(ms / 1000)}s`;
     if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
     if (ms < 86400000) return `${Math.round(ms / 3600000)}h`;
     return `${Math.round(ms / 86400000)}d`;
   };
+
+  const timelineEntries = selectedIncident ? buildTimelineEntries(selectedIncident) : [];
 
   return (
     <Layout>
@@ -479,30 +579,93 @@ export function Incidents() {
               )}
 
               <div style={{ marginBottom: '20px' }}>
-                <h3 style={{ fontSize: '16px', fontWeight: '600', marginBottom: '12px' }}>Notes</h3>
-                <div style={{ maxHeight: '200px', overflow: 'auto', display: 'flex', flexDirection: 'column', gap: '10px' }}>
-                  {selectedIncident.notes.length === 0 ? (
-                    <div style={{ color: '#94a3b8', fontSize: '14px' }}>No notes yet</div>
-                  ) : (
-                    selectedIncident.notes.map((note, idx) => (
-                      <div
-                        key={idx}
+                <h3 style={{ fontSize: '16px', fontWeight: '600', marginBottom: '12px' }}>Playbook Actions</h3>
+                <div style={{ display: 'grid', gap: '10px' }}>
+                  {playbookActions.map((action) => (
+                    <div
+                      key={action.key}
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: '12px 14px',
+                        borderRadius: '8px',
+                        border: '1px solid #e2e8f0',
+                        backgroundColor: '#f8fafc',
+                      }}
+                    >
+                      <div>
+                        <div style={{ fontWeight: '600', marginBottom: '4px' }}>{action.label}</div>
+                        <div style={{ color: '#64748b', fontSize: '13px' }}>{action.description}</div>
+                      </div>
+                      <button
+                        onClick={() => handlePlaybookAction(selectedIncident.id, action)}
+                        disabled={actionInProgress === action.key}
                         style={{
-                          padding: '12px',
-                          backgroundColor: '#f8fafc',
+                          backgroundColor: actionInProgress === action.key ? '#94a3b8' : '#0f172a',
+                          color: 'white',
+                          padding: '8px 14px',
+                          border: 'none',
                           borderRadius: '6px',
-                          fontSize: '14px',
+                          cursor: actionInProgress === action.key ? 'wait' : 'pointer',
+                          fontSize: '12px',
+                          fontWeight: '600',
                         }}
                       >
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
-                          <span style={{ fontWeight: '600' }}>{note.author}</span>
-                          <span style={{ color: '#64748b', fontSize: '12px' }}>
-                            {format(new Date(note.timestamp), 'MMM dd, HH:mm')}
-                          </span>
+                        {actionInProgress === action.key ? 'Running...' : 'Run'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div style={{ marginBottom: '20px' }}>
+                <h3 style={{ fontSize: '16px', fontWeight: '600', marginBottom: '12px' }}>Timeline</h3>
+                <div style={{ maxHeight: '260px', overflow: 'auto', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                  {timelineEntries.length === 0 ? (
+                    <div style={{ color: '#94a3b8', fontSize: '14px' }}>No timeline events yet</div>
+                  ) : (
+                    timelineEntries.map((entry) => {
+                      const style = timelineTypeStyles[entry.type];
+                      return (
+                        <div
+                          key={entry.id}
+                          style={{
+                            padding: '12px',
+                            borderRadius: '8px',
+                            border: `1px solid ${style.border}`,
+                            backgroundColor: 'white',
+                          }}
+                        >
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                              <span
+                                style={{
+                                  padding: '2px 8px',
+                                  borderRadius: '999px',
+                                  backgroundColor: style.bg,
+                                  color: style.text,
+                                  fontSize: '11px',
+                                  fontWeight: '600',
+                                }}
+                              >
+                                {style.label}
+                              </span>
+                              <span style={{ fontWeight: '600', fontSize: '14px' }}>{entry.summary}</span>
+                            </div>
+                            <span style={{ color: '#64748b', fontSize: '12px' }}>
+                              {format(new Date(entry.timestamp), 'MMM dd, HH:mm')} · {formatDistanceToNow(new Date(entry.timestamp), { addSuffix: true })}
+                            </span>
+                          </div>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', color: '#64748b', fontSize: '12px' }}>
+                            <span>Actor: <strong style={{ color: '#0f172a' }}>{entry.actor}</strong></span>
+                            {entry.type === 'action' && (
+                              <span style={{ color: '#16a34a', fontWeight: '600' }}>Audit logged</span>
+                            )}
+                          </div>
                         </div>
-                        <div style={{ color: '#475569' }}>{note.content}</div>
-                      </div>
-                    ))
+                      );
+                    })
                   )}
                 </div>
               </div>
@@ -790,4 +953,3 @@ function CreateIncidentForm({ onSuccess, onCancel }: { onSuccess: () => void; on
     </form>
   );
 }
-

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -139,6 +139,17 @@ export type IncidentType =
   | 'unauthorized_access'
   | 'other';
 
+export type IncidentTimelineEntryType = 'note' | 'status_change' | 'assignment' | 'action';
+
+export interface IncidentTimelineEntry {
+  id: string;
+  type: IncidentTimelineEntryType;
+  timestamp: number;
+  actor: string;
+  summary: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface Incident {
   id: string;
   title: string;
@@ -160,6 +171,7 @@ export interface Incident {
     author: string;
     content: string;
   }>;
+  timeline: IncidentTimelineEntry[];
   tags: string[];
   metadata?: Record<string, unknown>;
 }

--- a/src/modules/admin/admin.routes.ts
+++ b/src/modules/admin/admin.routes.ts
@@ -615,6 +615,38 @@ export async function registerAdminRoutes(
   );
 
   /**
+   * POST /admin/incidents/:id/actions
+   * Execute a playbook action (mocked)
+   */
+  app.post(
+    '/admin/incidents/:id/actions',
+    {
+      schema: {
+        description: 'Execute a playbook action for an incident (mocked)',
+        tags: ['Incident Response'],
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          required: ['action'],
+          properties: {
+            action: { type: 'string' },
+            target: { type: 'string' },
+          },
+        },
+      },
+      preHandler: adminAuth,
+    },
+    incidentController.executePlaybookAction.bind(incidentController)
+  );
+
+  /**
    * PATCH /admin/incidents/:id
    * Update incident details
    */

--- a/src/modules/admin/incident-response.controller.ts
+++ b/src/modules/admin/incident-response.controller.ts
@@ -170,6 +170,29 @@ export class IncidentResponseController {
   }
 
   /**
+   * POST /admin/incidents/:id/actions
+   * Execute a playbook action (mocked)
+   */
+  async executePlaybookAction(request: FastifyRequest, reply: FastifyReply) {
+    const user = (request as any).user;
+    const params = request.params as any;
+    const body = request.body as any;
+
+    const incident = await this.incidentService.executePlaybookAction(
+      params.id,
+      body.action,
+      user.username,
+      body.target
+    );
+
+    if (!incident) {
+      return reply.code(404).send({ error: 'Incident not found' });
+    }
+
+    return reply.send({ incident });
+  }
+
+  /**
    * POST /admin/incidents/seed-test-data
    * Seed test incidents for development/demo purposes
    */
@@ -235,4 +258,3 @@ export class IncidentResponseController {
     }
   }
 }
-

--- a/src/modules/admin/incident-response.service.ts
+++ b/src/modules/admin/incident-response.service.ts
@@ -21,6 +21,17 @@ export type IncidentType =
   | 'unauthorized_access'
   | 'other';
 
+export type IncidentTimelineEntryType = 'note' | 'status_change' | 'assignment' | 'action';
+
+export interface IncidentTimelineEntry {
+  id: string;
+  type: IncidentTimelineEntryType;
+  timestamp: number;
+  actor: string;
+  summary: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface Incident {
   id: string;
   title: string;
@@ -42,6 +53,7 @@ export interface Incident {
     author: string;
     content: string;
   }>;
+  timeline: IncidentTimelineEntry[];
   tags: string[];
   metadata?: Record<string, unknown>;
 }
@@ -88,6 +100,7 @@ export class IncidentResponseService {
     tags?: string[];
     metadata?: Record<string, unknown>;
   }): Promise<Incident> {
+    const now = Date.now();
     const incident: Incident = {
       id: nanoid(),
       title: params.title,
@@ -95,12 +108,25 @@ export class IncidentResponseService {
       type: params.type,
       severity: params.severity,
       status: 'open',
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
+      createdAt: now,
+      updatedAt: now,
       reportedBy: params.reportedBy,
       affectedIPs: params.affectedIPs || [],
       affectedUsers: params.affectedUsers || [],
       notes: [],
+      timeline: [
+        {
+          id: nanoid(),
+          type: 'note',
+          timestamp: now,
+          actor: params.reportedBy,
+          summary: 'Incident created',
+          metadata: {
+            severity: params.severity,
+            type: params.type,
+          },
+        },
+      ],
       tags: params.tags || [],
       metadata: params.metadata,
     };
@@ -120,7 +146,14 @@ export class IncidentResponseService {
   async getIncident(id: string): Promise<Incident | null> {
     const key = `${this.INCIDENT_KEY_PREFIX}${id}`;
     const data = await this.redis.get(key);
-    return data ? JSON.parse(data) : null;
+    if (!data) return null;
+    const incident = JSON.parse(data) as Incident;
+    const hadTimeline = Boolean(incident.timeline?.length);
+    const normalized = this.ensureTimeline(incident);
+    if (!hadTimeline && normalized.timeline?.length) {
+      await this.redis.setex(key, this.INCIDENT_RETENTION, JSON.stringify(normalized));
+    }
+    return normalized;
   }
 
   /**
@@ -157,7 +190,7 @@ export class IncidentResponseService {
           if (params?.severity && incident.severity !== params.severity) continue;
           if (params?.type && incident.type !== params.type) continue;
 
-          incidents.push(incident);
+          incidents.push(this.ensureTimeline(incident));
         }
       }
     }
@@ -184,6 +217,16 @@ export class IncidentResponseService {
       incident.resolvedAt = now;
       incident.resolutionTime = now - incident.createdAt;
     }
+
+    this.addTimelineEntry(incident, {
+      type: 'status_change',
+      timestamp: now,
+      actor: updatedBy,
+      summary: `Status changed to ${status}`,
+      metadata: {
+        status,
+      },
+    });
 
     // Add note about status change
     incident.notes.push({
@@ -216,6 +259,16 @@ export class IncidentResponseService {
       incident.responseTime = now - incident.createdAt;
     }
 
+    this.addTimelineEntry(incident, {
+      type: 'assignment',
+      timestamp: now,
+      actor: updatedBy,
+      summary: `Assigned to ${assignedTo}`,
+      metadata: {
+        assignedTo,
+      },
+    });
+
     incident.notes.push({
       timestamp: now,
       author: updatedBy,
@@ -235,12 +288,19 @@ export class IncidentResponseService {
     const incident = await this.getIncident(id);
     if (!incident) return null;
 
+    const now = Date.now();
     incident.notes.push({
-      timestamp: Date.now(),
+      timestamp: now,
       author,
       content,
     });
-    incident.updatedAt = Date.now();
+    incident.updatedAt = now;
+    this.addTimelineEntry(incident, {
+      type: 'note',
+      timestamp: now,
+      actor: author,
+      summary: content,
+    });
 
     const key = `${this.INCIDENT_KEY_PREFIX}${id}`;
     await this.redis.setex(key, this.INCIDENT_RETENTION, JSON.stringify(incident));
@@ -260,18 +320,137 @@ export class IncidentResponseService {
     if (!incident) return null;
 
     Object.assign(incident, updates);
-    incident.updatedAt = Date.now();
+    const now = Date.now();
+    incident.updatedAt = now;
 
     incident.notes.push({
-      timestamp: Date.now(),
+      timestamp: now,
       author: updatedBy,
       content: 'Incident details updated',
+    });
+    this.addTimelineEntry(incident, {
+      type: 'note',
+      timestamp: now,
+      actor: updatedBy,
+      summary: 'Incident details updated',
     });
 
     const key = `${this.INCIDENT_KEY_PREFIX}${id}`;
     await this.redis.setex(key, this.INCIDENT_RETENTION, JSON.stringify(incident));
 
     return incident;
+  }
+
+  /**
+   * Execute a playbook action (mocked)
+   */
+  async executePlaybookAction(
+    id: string,
+    action: string,
+    actor: string,
+    target?: string
+  ): Promise<Incident | null> {
+    const incident = await this.getIncident(id);
+    if (!incident) return null;
+
+    const now = Date.now();
+    const actionLabel = action
+      .split('_')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+    const summary = `Playbook action: ${actionLabel}${target ? ` (${target})` : ''}`;
+
+    this.addTimelineEntry(incident, {
+      type: 'action',
+      timestamp: now,
+      actor,
+      summary,
+      metadata: {
+        action,
+        target,
+        status: 'completed',
+        result: 'mocked',
+      },
+    });
+
+    incident.updatedAt = now;
+
+    const key = `${this.INCIDENT_KEY_PREFIX}${id}`;
+    await this.redis.setex(key, this.INCIDENT_RETENTION, JSON.stringify(incident));
+
+    logger.info({ incidentId: id, action, actor, target }, 'Incident playbook action executed');
+
+    return incident;
+  }
+
+  private addTimelineEntry(
+    incident: Incident,
+    entry: Omit<IncidentTimelineEntry, 'id'>
+  ) {
+    if (!incident.timeline) {
+      incident.timeline = [];
+    }
+    incident.timeline.push({
+      id: nanoid(),
+      ...entry,
+    });
+  }
+
+  private ensureTimeline(incident: Incident): Incident {
+    if (incident.timeline && incident.timeline.length > 0) {
+      return incident;
+    }
+
+    const timeline: IncidentTimelineEntry[] = [];
+    if (incident.createdAt) {
+      timeline.push({
+        id: nanoid(),
+        type: 'note',
+        timestamp: incident.createdAt,
+        actor: incident.reportedBy || 'system',
+        summary: 'Incident created',
+      });
+    }
+
+    if (incident.notes?.length) {
+      incident.notes.forEach(note => {
+        const normalized = this.normalizeNoteToTimeline(note.content);
+        timeline.push({
+          id: nanoid(),
+          type: normalized.type,
+          timestamp: note.timestamp,
+          actor: note.author,
+          summary: note.content,
+          metadata: normalized.metadata,
+        });
+      });
+    }
+
+    incident.timeline = timeline.sort((a, b) => a.timestamp - b.timestamp);
+    return incident;
+  }
+
+  private normalizeNoteToTimeline(content: string): {
+    type: IncidentTimelineEntryType;
+    metadata?: Record<string, unknown>;
+  } {
+    if (content.startsWith('Status changed to ')) {
+      return {
+        type: 'status_change',
+        metadata: {
+          status: content.replace('Status changed to ', ''),
+        },
+      };
+    }
+    if (content.startsWith('Assigned to ')) {
+      return {
+        type: 'assignment',
+        metadata: {
+          assignedTo: content.replace('Assigned to ', ''),
+        },
+      };
+    }
+    return { type: 'note' };
   }
 
   /**
@@ -407,4 +586,3 @@ export class IncidentResponseService {
     });
   }
 }
-


### PR DESCRIPTION
### Motivation

- Provide a single chronological view of incident activity (notes, status changes, assignments, and actions) to improve incident investigation and auditing. 
- Persist a unified `timeline` on incidents so frontend can render events reliably rather than infer from notes. 
- Expose simple, predefined playbook actions (mocked) to demonstrate common response workflows and produce audit entries. 
- Surface action audit logs in the UI so operators can see that actions were executed and recorded.

### Description

- Added timeline types and structures via `IncidentTimelineEntry` and `IncidentTimelineEntryType` and extended the `Incident` model to include a `timeline` array (backend: `src/modules/admin/incident-response.service.ts`, frontend types: `dashboard/src/types/index.ts`).
- Implemented timeline management in the service with `addTimelineEntry`, `ensureTimeline` (normalizes legacy `notes` into timeline entries), and created a mocked `executePlaybookAction` method that logs action entries and metadata to the timeline. 
- Exposed a new endpoint `POST /admin/incidents/:id/actions` via `IncidentResponseController.executePlaybookAction` and `admin.routes` and added a client helper `adminApi.runIncidentAction` in `dashboard/src/api/admin.ts`.
- Updated the dashboard incident detail modal (`dashboard/src/pages/Incidents.tsx`) to show a chronological "Timeline" section, render `note`, `status_change`, `assignment`, and `action` entries, and add playbook action controls (`Disable user`, `Block IP`, `Open ticket`) that call the mocked backend hooks and show action audit annotations.

### Testing

- Started the dashboard dev server with `npm run dev` and performed a smoke test that navigated to `/incidents` using an automated Playwright script to capture a screenshot, which completed successfully. 
- No unit or integration test suites were executed as part of this change; TypeScript/Jest test runs were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69659097d98c8325b875ff44d873e982)