### PR TITLE
Fix dark mode (and make it default), fix dead links, add MkDocs GitHub Pages site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+name: Docs (MkDocs -> GitHub Pages)
+
+# Builds the documentation site (mkdocs.yml + docs/) and deploys it to GitHub Pages.
+#
+# Required one-time setup: repo Settings -> Pages -> Source: "GitHub Actions" (not
+# "Deploy from a branch"). Without that, the deploy job below will fail even though
+# the build succeeds - GitHub Pages has to be explicitly switched to Actions-based
+# deployment before this workflow's `actions/deploy-pages` step has anywhere to publish
+# to. Once enabled, the site is served at https://<owner>.github.io/<repo>/, matching
+# `site_url` in mkdocs.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'openapi/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (mkdocs --strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-lock.yaml
 dist/
 build/
 *.tsbuildinfo
+site/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ curl http://localhost:3000/admin/audit-logs/verify -H "Authorization: Bearer <ad
 Full OpenAPI spec: [`openapi/openapi.yaml`](openapi/openapi.yaml) (also served at
 `/docs` when `ENABLE_SWAGGER=true`).
 
+## Documentation site
+
+The full reference documentation - architecture, threat model, detection rules,
+security controls, operations runbooks, and an interactive API reference generated
+from the same OpenAPI spec above - is published at
+**[jasonachkar.github.io/secure-api-gateway](https://jasonachkar.github.io/secure-api-gateway/)**,
+built with [MkDocs](https://www.mkdocs.org/) + [Material](https://squidfunk.github.io/mkdocs-material/)
+from [`mkdocs.yml`](mkdocs.yml) and [`docs/`](docs), deployed by
+[`.github/workflows/docs.yml`](.github/workflows/docs.yml) on every push to `main`.
+To build it locally: `pip install -r docs/requirements.txt && mkdocs serve`.
+
 ## Azure deployment
 
 ```bash
@@ -341,6 +352,7 @@ push/PR.
 | `dependency-review.yml` | Dependency Review (PRs), `npm audit`, SBOM generation |
 | `deploy.yml` | Manual (`workflow_dispatch`): build → push to ACR → `az containerapp update` |
 | `deploy-dashboard.yml` | Deploys the dashboard to Azure Static Web Apps when enabled |
+| `docs.yml` | Builds the MkDocs documentation site and deploys it to GitHub Pages |
 
 All SARIF output uploads to GitHub code scanning. `deploy.yml` documents the exact
 repo secrets it needs and an OIDC federated-credential setup (no long-lived Azure

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Security Dashboard - API Gateway</title>
     <script>
-      // Set the theme before first paint so there's no flash of the wrong theme -
-      // ThemeContext (src/contexts/ThemeContext.tsx) owns this value after hydration.
+      // Set the theme before first paint so there's no flash of the wrong theme - must
+      // match ThemeContext.tsx's getInitialTheme() exactly, which owns this value after
+      // hydration. Dark is the unconditional default for first-time visitors - see that
+      // file for why this deliberately ignores prefers-color-scheme.
       (function () {
         try {
           var stored = localStorage.getItem('dashboard-theme');
-          var theme = stored === 'light' || stored === 'dark'
-            ? stored
-            : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          var theme = stored === 'light' || stored === 'dark' ? stored : 'dark';
           document.documentElement.setAttribute('data-theme', theme);
         } catch (e) {}
       })();

--- a/dashboard/src/components/ErrorRateChart.tsx
+++ b/dashboard/src/components/ErrorRateChart.tsx
@@ -5,7 +5,6 @@
 
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { format } from 'date-fns';
-import { theme } from '../styles/theme';
 import { ChartTooltip } from './ChartTooltip';
 
 interface DataPoint {
@@ -54,11 +53,11 @@ export function ErrorRateChart({ data, title = 'Error Rate', isLoading = false }
           <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" />
           <XAxis
             dataKey="time"
-            stroke={theme.colors.text.tertiary}
+            stroke="var(--color-text-tertiary)"
             tick={{ className: 'chart-axis-tick' }}
           />
           <YAxis
-            stroke={theme.colors.text.tertiary}
+            stroke="var(--color-text-tertiary)"
             tick={{ className: 'chart-axis-tick' }}
             label={{ 
               value: 'Errors/sec', 

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -179,6 +179,13 @@ export function Layout({ children }: LayoutProps) {
           )}
         </nav>
 
+        {/* Fixed (non-theme-reactive) colors below are intentional: the sidebar itself
+            always renders dark (--gradient-sidebar, unchanged in styles/tokens.css's dark
+            section) regardless of the app-wide theme, so a fixed light-mode neutral-700
+            reads correctly against it in both modes. Swapping these to var(--color-neutral-700)
+            would break dark mode instead of fixing it - that var resolves to a near-white
+            value in dark mode (inverted for on-dark-surface use elsewhere), which would
+            render as a bright, jarring box against this always-dark sidebar. */}
         <div style={{
           paddingTop: theme.spacing.lg,
           borderTop: `1px solid ${theme.colors.neutral[700]}`,
@@ -223,7 +230,7 @@ export function Layout({ children }: LayoutProps) {
       {/* Enhanced Main Content */}
       <main style={{
         flex: 1,
-        backgroundColor: theme.colors.background.secondary,
+        backgroundColor: 'var(--color-bg-secondary)',
         padding: theme.spacing.xl,
         minHeight: '100vh',
         maxWidth: '100%',

--- a/dashboard/src/components/RequestRateChart.tsx
+++ b/dashboard/src/components/RequestRateChart.tsx
@@ -5,7 +5,6 @@
 
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { format } from 'date-fns';
-import { theme } from '../styles/theme';
 import { ChartTooltip } from './ChartTooltip';
 
 interface DataPoint {
@@ -42,11 +41,11 @@ export function RequestRateChart({ data, title = 'Request Rate', isLoading = fal
           <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" />
           <XAxis
             dataKey="time"
-            stroke={theme.colors.text.tertiary}
+            stroke="var(--color-text-tertiary)"
             tick={{ className: 'chart-axis-tick' }}
           />
           <YAxis
-            stroke={theme.colors.text.tertiary}
+            stroke="var(--color-text-tertiary)"
             tick={{ className: 'chart-axis-tick' }}
             label={{ 
               value: 'Requests/sec', 

--- a/dashboard/src/components/ResponseTimeChart.tsx
+++ b/dashboard/src/components/ResponseTimeChart.tsx
@@ -5,7 +5,6 @@
 
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 import { format } from 'date-fns';
-import { theme } from '../styles/theme';
 import { ChartTooltip } from './ChartTooltip';
 
 interface ResponseTimeDataPoint {
@@ -46,11 +45,11 @@ export function ResponseTimeChart({ data, title = 'Response Time Percentiles', i
           <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light)" />
           <XAxis 
             dataKey="time" 
-            stroke={theme.colors.text.tertiary} 
+            stroke="var(--color-text-tertiary)"
             tick={{ className: 'chart-axis-tick' }}
           />
           <YAxis 
-            stroke={theme.colors.text.tertiary} 
+            stroke="var(--color-text-tertiary)"
             tick={{ className: 'chart-axis-tick' }}
             label={{ 
               value: 'ms', 

--- a/dashboard/src/contexts/ThemeContext.tsx
+++ b/dashboard/src/contexts/ThemeContext.tsx
@@ -1,6 +1,11 @@
 /**
- * Dark mode. Defaults to the OS/browser preference (prefers-color-scheme), persists the
- * user's explicit choice in localStorage, and stamps `data-theme` on <html> - every color
+ * Dark mode is the default, unconditionally, for every first-time visitor. This
+ * deliberately does NOT fall back to `prefers-color-scheme` the way many apps do:
+ * most operating systems ship with a light theme out of the box, so `prefers-color-scheme:
+ * light` matches by default for the large majority of visitors who have never touched
+ * their OS appearance setting at all - honoring that as a signal would make the app
+ * default to light for almost everyone, which defeats the point. Persists the user's
+ * explicit toggle choice in localStorage, and stamps `data-theme` on <html> - every color
  * in styles/ui.css and styles/tokens.css is a CSS custom property, so this alone re-themes
  * the whole app without page-by-page changes.
  */
@@ -21,7 +26,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 function getInitialTheme(): ThemeMode {
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === 'light' || stored === 'dark') return stored;
-  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  return 'dark';
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {

--- a/dashboard/src/pages/AuditLogs.tsx
+++ b/dashboard/src/pages/AuditLogs.tsx
@@ -1,10 +1,9 @@
 /**
  * Admin Audit Logs page
- * Displays administrative actions with incident links
+ * Displays administrative actions
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { RefreshCw } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import { Button } from '../components/Button';
@@ -150,7 +149,7 @@ export function AuditLogs() {
             <p
               style={{
                 ...theme.typography.body,
-                color: theme.colors.text.secondary,
+                color: 'var(--color-text-secondary)',
               }}
             >
               Administrative action history across the platform
@@ -185,11 +184,11 @@ export function AuditLogs() {
 
         <div
           style={{
-            background: theme.colors.background.primary,
+            background: 'var(--color-bg-primary)',
             borderRadius: theme.borderRadius.lg,
             padding: theme.spacing.lg,
             marginBottom: theme.spacing.lg,
-            border: `1px solid ${theme.colors.border.light}`,
+            border: '1px solid var(--color-border-light)',
           }}
         >
           <div
@@ -208,7 +207,7 @@ export function AuditLogs() {
               onChange={(e) => handleFilterChange('actorId', e.target.value)}
               style={{
                 padding: theme.spacing.sm,
-                border: `1px solid ${theme.colors.border.medium}`,
+                border: '1px solid var(--color-border-medium)',
                 borderRadius: theme.borderRadius.sm,
               }}
             />
@@ -220,7 +219,7 @@ export function AuditLogs() {
               onChange={(e) => handleFilterChange('action', e.target.value)}
               style={{
                 padding: theme.spacing.sm,
-                border: `1px solid ${theme.colors.border.medium}`,
+                border: '1px solid var(--color-border-medium)',
                 borderRadius: theme.borderRadius.sm,
               }}
             />
@@ -232,7 +231,7 @@ export function AuditLogs() {
               onChange={(e) => handleFilterChange('incidentId', e.target.value)}
               style={{
                 padding: theme.spacing.sm,
-                border: `1px solid ${theme.colors.border.medium}`,
+                border: '1px solid var(--color-border-medium)',
                 borderRadius: theme.borderRadius.sm,
               }}
             />
@@ -263,16 +262,16 @@ export function AuditLogs() {
 
         <div
           style={{
-            background: theme.colors.background.primary,
+            background: 'var(--color-bg-primary)',
             borderRadius: theme.borderRadius.lg,
-            border: `1px solid ${theme.colors.border.light}`,
+            border: '1px solid var(--color-border-light)',
             overflow: 'hidden',
           }}
         >
           <div style={{ overflowX: 'auto' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
-                <tr style={{ background: theme.colors.background.secondary }}>
+                <tr style={{ background: 'var(--color-bg-secondary)' }}>
                   {['Timestamp', 'Actor', 'Action', 'Incident'].map((header) => (
                     <th
                       key={header}
@@ -280,8 +279,8 @@ export function AuditLogs() {
                         textAlign: 'left',
                         padding: theme.spacing.md,
                         fontSize: theme.typography.fontSize.sm,
-                        color: theme.colors.text.secondary,
-                        borderBottom: `1px solid ${theme.colors.border.light}`,
+                        color: 'var(--color-text-secondary)',
+                        borderBottom: '1px solid var(--color-border-light)',
                       }}
                     >
                       {header}
@@ -294,7 +293,7 @@ export function AuditLogs() {
                   Array.from({ length: 8 }).map((_, rowIdx) => (
                     <tr
                       key={`skeleton-${rowIdx}`}
-                      style={{ borderBottom: `1px solid ${theme.colors.border.light}` }}
+                      style={{ borderBottom: '1px solid var(--color-border-light)' }}
                       aria-hidden="true"
                     >
                       {['55%', '70%', '65%', '40%'].map((width, cellIdx) => (
@@ -324,32 +323,27 @@ export function AuditLogs() {
                   </tr>
                 ) : (
                   logs.map((log) => (
-                    <tr key={log.id} style={{ borderBottom: `1px solid ${theme.colors.border.light}` }}>
+                    <tr key={log.id} style={{ borderBottom: '1px solid var(--color-border-light)' }}>
                       <td style={{ padding: theme.spacing.md }}>
                         {format(new Date(log.timestamp), 'MMM dd, yyyy HH:mm:ss')}
                       </td>
                       <td style={{ padding: theme.spacing.md }}>
                         <div style={{ fontWeight: 600 }}>{log.actor.username}</div>
-                        <div style={{ color: theme.colors.text.secondary, fontSize: theme.typography.fontSize.sm }}>
+                        <div style={{ color: 'var(--color-text-secondary)', fontSize: theme.typography.fontSize.sm }}>
                           {log.actor.userId}
                         </div>
                       </td>
                       <td style={{ padding: theme.spacing.md }}>
                         <div style={{ fontWeight: 600 }}>{log.action}</div>
-                        <div style={{ color: theme.colors.text.secondary, fontSize: theme.typography.fontSize.sm }}>
+                        <div style={{ color: 'var(--color-text-secondary)', fontSize: theme.typography.fontSize.sm }}>
                           {log.resource}
                         </div>
                       </td>
                       <td style={{ padding: theme.spacing.md }}>
                         {log.incidentId ? (
-                          <Link
-                            to={`/incidents?incidentId=${encodeURIComponent(log.incidentId)}`}
-                            style={{ color: theme.colors.primary[500], textDecoration: 'none' }}
-                          >
-                            {log.incidentId}
-                          </Link>
+                          <code className="text-mono text-sm">{log.incidentId}</code>
                         ) : (
-                          <span style={{ color: theme.colors.text.secondary }}>—</span>
+                          <span style={{ color: 'var(--color-text-secondary)' }}>—</span>
                         )}
                       </td>
                     </tr>
@@ -362,13 +356,13 @@ export function AuditLogs() {
           <div
             style={{
               padding: theme.spacing.md,
-              borderTop: `1px solid ${theme.colors.border.light}`,
+              borderTop: '1px solid var(--color-border-light)',
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
             }}
           >
-            <div style={{ color: theme.colors.text.secondary, fontSize: theme.typography.fontSize.sm }}>
+            <div style={{ color: 'var(--color-text-secondary)', fontSize: theme.typography.fontSize.sm }}>
               Showing {startIndex}-{endIndex} of {allLogs.length}
             </div>
             <div style={{ display: 'flex', gap: theme.spacing.sm }}>

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -285,7 +285,7 @@ export function Dashboard() {
 
         {posture && (
           <div style={{
-            backgroundColor: theme.colors.background.primary,
+            backgroundColor: 'var(--color-bg-primary)',
             padding: theme.spacing.lg,
             borderRadius: theme.borderRadius.lg,
             boxShadow: theme.shadows.md,
@@ -337,7 +337,7 @@ export function Dashboard() {
             }}>
               <div>
                 <h2 style={{ ...theme.typography.h3 }}>Ingestion Status</h2>
-                <p style={{ ...theme.typography.small, color: theme.colors.text.secondary }}>
+                <p style={{ ...theme.typography.small, color: 'var(--color-text-secondary)' }}>
                   Normalized event pipeline health and adapter readiness
                 </p>
               </div>
@@ -388,11 +388,11 @@ export function Dashboard() {
             }}>
               {ingestionStatus.adapters.map(adapter => (
                 <div key={adapter.provider} style={{
-                  backgroundColor: theme.colors.background.primary,
+                  backgroundColor: 'var(--color-bg-primary)',
                   padding: theme.spacing.md,
                   borderRadius: theme.borderRadius.lg,
                   boxShadow: theme.shadows.sm,
-                  border: `1px solid ${theme.colors.border.light}`,
+                  border: '1px solid var(--color-border-light)',
                 }}>
                   <div style={{
                     display: 'flex',
@@ -416,7 +416,7 @@ export function Dashboard() {
                   </div>
                   <div style={{
                     ...theme.typography.small,
-                    color: theme.colors.text.secondary,
+                    color: 'var(--color-text-secondary)',
                   }}>
                     {adapter.detail || 'Status unavailable'}
                   </div>

--- a/dashboard/src/pages/GuidedScenarios.tsx
+++ b/dashboard/src/pages/GuidedScenarios.tsx
@@ -26,8 +26,8 @@ const PROVENANCE_VARIANT: Record<string, 'success' | 'info' | 'neutral'> = {
 };
 
 function StepIcon({ status }: { status: 'completed' | 'skipped' | 'failed' }) {
-  if (status === 'completed') return <CheckCircle2 size={16} color="var(--color-success-600, #16a34a)" aria-hidden="true" />;
-  if (status === 'failed') return <XCircle size={16} color="var(--color-danger-600, #dc2626)" aria-hidden="true" />;
+  if (status === 'completed') return <CheckCircle2 size={16} color="var(--color-success-600)" aria-hidden="true" />;
+  if (status === 'failed') return <XCircle size={16} color="var(--color-error-600)" aria-hidden="true" />;
   return <MinusCircle size={16} className="text-muted" aria-hidden="true" />;
 }
 
@@ -161,7 +161,7 @@ export function GuidedScenarios() {
               </ol>
 
               {result && (
-                <div className="text-sm text-muted" style={{ marginTop: 12, borderTop: '1px solid var(--color-border-subtle, #e5e7eb)', paddingTop: 12 }}>
+                <div className="text-sm text-muted" style={{ marginTop: 12, borderTop: '1px solid var(--color-border-light)', paddingTop: 12 }}>
                   Correlation ID: <code className="text-mono">{result.correlationId}</code>
                   {result.investigationIds.length > 0 && (
                     <>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -21,8 +21,8 @@ body {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
-  color: #0f172a;
-  background-color: #f8fafc;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
 }
 
 /* Smooth scroll */
@@ -32,13 +32,13 @@ html {
 
 /* Focus states for accessibility */
 *:focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-primary-500);
   outline-offset: 2px;
 }
 
 button:focus-visible,
 a:focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-primary-500);
   outline-offset: 2px;
 }
 
@@ -49,23 +49,23 @@ a:focus-visible {
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f5f9;
+  background: var(--color-bg-tertiary);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
+  background: var(--color-border-medium);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
+  background: var(--color-border-dark);
 }
 
 /* Firefox scrollbar */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #cbd5e1 #f1f5f9;
+  scrollbar-color: var(--color-border-medium) var(--color-bg-tertiary);
 }
 
 /* Typography utilities */
@@ -135,16 +135,6 @@ a:focus-visible {
 .p-md { padding: 16px; }
 .p-lg { padding: 24px; }
 .p-xl { padding: 32px; }
-
-/* Color utilities */
-.text-primary { color: #0f172a; }
-.text-secondary { color: #475569; }
-.text-tertiary { color: #64748b; }
-.text-inverse { color: #ffffff; }
-
-.bg-primary { background-color: #ffffff; }
-.bg-secondary { background-color: #f8fafc; }
-.bg-tertiary { background-color: #f1f5f9; }
 
 /* Animation utilities */
 @keyframes fadeIn {

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -997,6 +997,8 @@ body {
 
 .metric-card__trend-icon.metric-card__trend--good { color: var(--color-success-600); }
 .metric-card__trend-icon.metric-card__trend--bad { color: var(--color-error-600); }
+:root[data-theme='dark'] .metric-card__trend-icon.metric-card__trend--good { color: var(--color-success-400); }
+:root[data-theme='dark'] .metric-card__trend-icon.metric-card__trend--bad { color: var(--color-error-400); }
 
 .metric-card__trend-label {
   font-size: 11px;
@@ -1007,6 +1009,8 @@ body {
 
 .metric-card__trend-label.metric-card__trend--good { color: var(--color-success-700); }
 .metric-card__trend-label.metric-card__trend--bad { color: var(--color-error-700); }
+:root[data-theme='dark'] .metric-card__trend-label.metric-card__trend--good { color: var(--color-success-400); }
+:root[data-theme='dark'] .metric-card__trend-label.metric-card__trend--bad { color: var(--color-error-400); }
 
 .metric-card__subtitle {
   font-size: 12px;
@@ -1172,14 +1176,42 @@ body {
   transition: background-color var(--transition-normal), transform var(--transition-normal);
 }
 
+/* Both modifiers below are a fixed light tint in both themes (semantic colors don't
+   change with theme). .live-feed__item-type/-time/-detail and .live-feed__message all
+   set their own theme-reactive text color (light in dark mode) by default, which is
+   correct against the default .live-feed__item background (which does darken) but would
+   be near-invisible against these fixed-light warning/critical backgrounds - the same
+   bug found and fixed on .session-card--concurrent below. */
 .live-feed__item--warning {
   border-left-color: var(--color-warning-400, var(--color-warning-500));
   background-color: var(--color-warning-50);
 }
 
+.live-feed__item--warning .live-feed__item-type,
+.live-feed__item--warning .live-feed__message {
+  color: var(--color-warning-900);
+}
+
+.live-feed__item--warning .live-feed__item-time,
+.live-feed__item--warning .live-feed__item-detail,
+.live-feed__item--warning .live-feed__user {
+  color: var(--color-warning-700);
+}
+
 .live-feed__item--critical {
   border-left-color: var(--color-error-500);
   background-color: var(--color-error-50);
+}
+
+.live-feed__item--critical .live-feed__item-type,
+.live-feed__item--critical .live-feed__message {
+  color: var(--color-error-900);
+}
+
+.live-feed__item--critical .live-feed__item-time,
+.live-feed__item--critical .live-feed__item-detail,
+.live-feed__item--critical .live-feed__user {
+  color: var(--color-error-700);
 }
 
 .live-feed__item:hover {
@@ -1467,14 +1499,25 @@ body {
 .threat-card--medium, .incident-card--medium { border-left-color: var(--color-warning-500); }
 .threat-card--low, .incident-card--low { border-left-color: var(--color-neutral-400); }
 
-.threat-card--blocked {
-  border-left-color: var(--color-error-600);
-  background-color: var(--color-error-50);
-}
-
+/* Fixed light tint in both themes (semantic colors don't change with theme) - text
+   pinned dark too, same fix and same reasoning as .session-card--concurrent above. */
+.threat-card--blocked,
 .user-card--locked {
   border-left-color: var(--color-error-600);
   background-color: var(--color-error-50);
+  color: var(--color-error-900);
+}
+
+.threat-card--blocked .threat-card__meta-label,
+.user-card--locked .threat-card__meta-label {
+  color: var(--color-error-700);
+}
+
+.threat-card--blocked .section-title,
+.threat-card--blocked .text-muted,
+.user-card--locked .section-title,
+.user-card--locked .text-muted {
+  color: var(--color-error-900);
 }
 
 .threat-card__header,
@@ -1526,6 +1569,11 @@ body {
 .threat-score--high { color: #ea580c; }
 .threat-score--medium { color: var(--color-warning-600); }
 .threat-score--low { color: var(--color-success-600); }
+
+:root[data-theme='dark'] .threat-score--critical { color: var(--color-error-400); }
+:root[data-theme='dark'] .threat-score--high { color: #fb923c; }
+:root[data-theme='dark'] .threat-score--medium { color: var(--color-warning-400); }
+:root[data-theme='dark'] .threat-score--low { color: var(--color-success-400); }
 
 .threat-pattern__description {
   color: var(--color-text-secondary);
@@ -1779,7 +1827,10 @@ body {
   position: sticky;
   top: 0;
   z-index: 20;
-  background-color: rgba(255, 255, 255, 0.85);
+  /* Was a hardcoded white translucency - rendered as a bright white bar over the dark
+     hero gradient in dark mode. color-mix() keeps the frosted-glass look while tracking
+     the current theme's actual background color. */
+  background-color: color-mix(in srgb, var(--color-bg-primary) 85%, transparent);
   backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--color-border-light);
 }
@@ -1958,6 +2009,14 @@ body {
 .text-success { color: var(--color-success-600); }
 .text-warning { color: var(--color-warning-600); }
 .text-muted { color: var(--color-text-tertiary); }
+
+/* These sit directly on whatever theme-reactive surface surrounds them (unlike a
+   self-contained badge with its own fixed light-tint background), so - same reasoning
+   as .github-status above - they need a lighter shade in dark mode to keep WCAG AA
+   contrast against a near-black page background. */
+:root[data-theme='dark'] .text-danger { color: var(--color-error-400); }
+:root[data-theme='dark'] .text-success { color: var(--color-success-400); }
+:root[data-theme='dark'] .text-warning { color: var(--color-warning-400); }
 .text-mono {
   font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, monospace;
 }
@@ -2002,6 +2061,10 @@ body {
 .toast--success .toast__icon { color: var(--color-success-600); }
 .toast--error .toast__icon { color: var(--color-error-600); }
 .toast--info .toast__icon { color: var(--color-primary-600); }
+
+:root[data-theme='dark'] .toast--success .toast__icon { color: var(--color-success-400); }
+:root[data-theme='dark'] .toast--error .toast__icon { color: var(--color-error-400); }
+:root[data-theme='dark'] .toast--info .toast__icon { color: var(--color-primary-400); }
 
 .toast__message {
   flex: 1;
@@ -2423,6 +2486,10 @@ body {
 .request-inspector__status--4xx { color: var(--color-warning-600); }
 .request-inspector__status--5xx { color: var(--color-error-600); }
 
+:root[data-theme='dark'] .request-inspector__status--2xx { color: var(--color-success-400); }
+:root[data-theme='dark'] .request-inspector__status--4xx { color: var(--color-warning-400); }
+:root[data-theme='dark'] .request-inspector__status--5xx { color: var(--color-error-400); }
+
 @media (prefers-reduced-motion: reduce) {
   .simulator-spin, .request-inspector__row--flash {
     animation: none;
@@ -2511,12 +2578,19 @@ body {
   font-weight: 600;
 }
 
-/* success-600/error-600 measured 3.14:1 / ~3.8:1 against this card's light background
-   (WCAG 2 AA needs 4.5:1 for normal text) - 700 clears both with margin. */
+/* success-600/error-600 measured 3.14:1 / ~3.8:1 against this card's light-mode
+   background (WCAG 2 AA needs 4.5:1 for normal text) - 700 clears both with margin.
+   .github-status sits on --color-bg-secondary, which is itself theme-reactive (unlike
+   the fixed-tint badge/alert pattern used elsewhere) - so unlike those, this text color
+   needs to invert per theme too: 700-weight shades that clear contrast against a light
+   background measure only ~3.5:1 against dark mode's near-black background. */
 .github-status__build--passing { color: var(--color-success-700); }
 .github-status__build--failing { color: var(--color-error-700); }
 .github-status__build--loading,
 .github-status__build--unknown { color: var(--color-text-tertiary); }
+
+:root[data-theme='dark'] .github-status__build--passing { color: var(--color-success-400); }
+:root[data-theme='dark'] .github-status__build--failing { color: var(--color-error-400); }
 
 .github-status__link {
   display: inline-flex;
@@ -2528,6 +2602,8 @@ body {
   text-decoration: none;
   margin-top: 4px;
 }
+
+:root[data-theme='dark'] .github-status__link { color: var(--color-primary-400); }
 
 .github-status__link:hover {
   text-decoration: underline;
@@ -2677,7 +2753,22 @@ body {
 
 .session-card--concurrent {
   border-left-color: var(--color-warning-500);
+  /* Fixed light warning tint in both themes (semantic colors don't change with theme -
+     see styles/tokens.css). Text must be pinned dark here too: .threat-card__meta-label/
+     .section-title/.text-muted below all set their own theme-reactive color (light in
+     dark mode), which would otherwise render near-invisible against this fixed light
+     background - a real bug found by screenshotting this page in dark mode. */
   background-color: var(--color-warning-50);
+  color: var(--color-warning-900);
+}
+
+.session-card--concurrent .threat-card__meta-label {
+  color: var(--color-warning-700);
+}
+
+.session-card--concurrent .section-title,
+.session-card--concurrent .text-muted {
+  color: var(--color-warning-900);
 }
 
 .session-card__flags {

--- a/dashboard/tests/e2e/reviewer-journey.spec.ts
+++ b/dashboard/tests/e2e/reviewer-journey.spec.ts
@@ -71,8 +71,12 @@ test.describe('Reviewer journey (one-click demo)', () => {
     // trigger a lockout, which shares RATE_LIMIT_AUTH_MAX with every other login in this
     // suite and would starve the Compliance test's real admin login below.
     await page.goto('/guided-scenarios');
+    await page.waitForLoadState('networkidle');
     const awsCard = page.locator('.ui-card', { hasText: 'AWS privileged activity' });
-    await awsCard.getByText('Run scenario').click();
+    const runButton = awsCard.getByText('Run scenario');
+    await expect(runButton).toBeVisible({ timeout: 15000 });
+    await runButton.scrollIntoViewIfNeeded();
+    await runButton.click();
     // Wait for the scenario's own "View investigation" result link (a real completion
     // signal from the run finishing) rather than a fixed timeout. 30s, not 15s - a CI
     // runner's first heavy request after a cold Node start can be slower than a warm

--- a/dashboard/tests/e2e/reviewer-journey.spec.ts
+++ b/dashboard/tests/e2e/reviewer-journey.spec.ts
@@ -63,8 +63,9 @@ test.describe('Reviewer journey (one-click demo)', () => {
 
   test('Investigations master-detail: filters narrow the list and selecting an item loads detail inline', async ({ page }) => {
     // Longer than the 30s default: this test's own wait for scenario completion below can
-    // take up to 30s alone in CI, which wouldn't leave room for the rest of the test.
-    test.setTimeout(60000);
+    // take up to 45s alone on a cold CI runner, which wouldn't leave room for the rest of
+    // the test.
+    test.setTimeout(90000);
     // Guarantee at least one investigation exists without depending on prior test-run state.
     // Deliberately runs the AWS replay scenario, not gw-credential-attack (listed first in
     // the UI) - the gateway scenario performs several real POST /auth/login attempts to
@@ -78,10 +79,12 @@ test.describe('Reviewer journey (one-click demo)', () => {
     await runButton.scrollIntoViewIfNeeded();
     await runButton.click();
     // Wait for the scenario's own "View investigation" result link (a real completion
-    // signal from the run finishing) rather than a fixed timeout. 30s, not 15s - a CI
-    // runner's first heavy request after a cold Node start can be slower than a warm
-    // local dev process even for a pure-replay scenario with no external calls.
-    await expect(awsCard.getByText(/View investigations?/)).toBeVisible({ timeout: 30000 });
+    // signal from the run finishing) rather than a fixed timeout. This has needed
+    // increasing more than once: a CI runner's first heavy request after a cold Node
+    // start - a full parse -> normalize -> detect -> correlate pass, several Redis
+    // round-trips - measured noticeably slower than a warm local dev process even for a
+    // pure-replay scenario with no external network calls.
+    await expect(awsCard.getByText(/View investigations?/)).toBeVisible({ timeout: 45000 });
 
     await page.goto('/investigations');
     await page.waitForLoadState('networkidle');

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,14 +40,14 @@ The frontend and backend deploy independently and communicate only over HTTPS:
 - **`dashboard/`** → Vercel by default. Static build, points at the gateway via
   `VITE_API_URL`. Optionally Azure Static Web Apps instead (`enable_azure_static_web_app`
   in Terraform) if you'd rather keep everything on one cloud - see
-  [`terraform/README.md`](../terraform/README.md#frontend-hosting-vercel-vs-azure-static-web-apps).
+  [`terraform/README.md`](https://github.com/jasonachkar/secure-api-gateway/blob/main/terraform/README.md#frontend-hosting-vercel-vs-azure-static-web-apps).
   Both give you a public HTTPS domain automatically, no custom domain required.
-- **everything else** → Azure, provisioned by [`terraform/`](../terraform). See
-  [`terraform/README.md`](../terraform/README.md) for the resource-by-resource
+- **everything else** → Azure, provisioned by [`terraform/`](https://github.com/jasonachkar/secure-api-gateway/tree/main/terraform). See
+  [`terraform/README.md`](https://github.com/jasonachkar/secure-api-gateway/blob/main/terraform/README.md) for the resource-by-resource
   breakdown and cost table.
 
 APIM is optional (`enable_apim` in Terraform, `false` by default) - see
-[`terraform/README.md`](../terraform/README.md#optional-all-false-by-default) for why
+[`terraform/README.md`](https://github.com/jasonachkar/secure-api-gateway/blob/main/terraform/README.md#optional-all-false-by-default) for why
 it's not part of the default path. Without it, the Container App is directly
 internet-facing; that's an intentional trust-boundary decision covered in
 [`THREAT_MODEL.md`](THREAT_MODEL.md).

--- a/docs/CLOUD_INGESTION.md
+++ b/docs/CLOUD_INGESTION.md
@@ -5,7 +5,7 @@
 Every way a security event enters this system - a live AWS/GCP poll, a manual fixture
 replay, or a guided scenario - runs through the exact same function:
 `ingestProviderEvent()` in
-[`src/modules/ingestion/security-ingestion.pipeline.ts`](../src/modules/ingestion/security-ingestion.pipeline.ts).
+[`src/modules/ingestion/security-ingestion.pipeline.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/ingestion/security-ingestion.pipeline.ts).
 
 ```
 raw provider payload
@@ -30,10 +30,10 @@ things that differ between entry points are:
 
 | Entry point | Provenance | Driver |
 | --- | --- | --- |
-| `POST /admin/security/replay` | `replay` | [`src/modules/ingestion/replay.ts`](../src/modules/ingestion/replay.ts) - loads a fixture via the allowlisted catalogue (see `docs/KNOWN_LIMITATIONS.md`), calls `ingestProviderEvent()`. |
-| Guided scenarios | `replay` (AWS/GCP) or `live` (gateway) | [`src/modules/scenarios/scenario.service.ts`](../src/modules/scenarios/scenario.service.ts) - same `replayFixtureThroughPipeline()` for cloud scenarios; the gateway scenario drives real HTTP requests through the actual auth route. |
-| AWS CloudWatch polling | `live` | [`src/modules/ingestion/adapters/cloudwatch.adapter.ts`](../src/modules/ingestion/adapters/cloudwatch.adapter.ts) |
-| GCP Cloud Logging polling | `live` | [`src/modules/ingestion/adapters/gcp-logging.adapter.ts`](../src/modules/ingestion/adapters/gcp-logging.adapter.ts) |
+| `POST /admin/security/replay` | `replay` | [`src/modules/ingestion/replay.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/ingestion/replay.ts) - loads a fixture via the allowlisted catalogue (see `docs/KNOWN_LIMITATIONS.md`), calls `ingestProviderEvent()`. |
+| Guided scenarios | `replay` (AWS/GCP) or `live` (gateway) | [`src/modules/scenarios/scenario.service.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/scenarios/scenario.service.ts) - same `replayFixtureThroughPipeline()` for cloud scenarios; the gateway scenario drives real HTTP requests through the actual auth route. |
+| AWS CloudWatch polling | `live` | [`src/modules/ingestion/adapters/cloudwatch.adapter.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/ingestion/adapters/cloudwatch.adapter.ts) |
+| GCP Cloud Logging polling | `live` | [`src/modules/ingestion/adapters/gcp-logging.adapter.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/ingestion/adapters/gcp-logging.adapter.ts) |
 | Azure | `replay` only | No live connector exists - see below. |
 
 ## AWS: CloudWatch Logs -> canonical pipeline
@@ -140,7 +140,7 @@ Credentials or Workload Identity Federation.
 ## Azure: replay only
 
 There is no live Azure connector. `AzureSentinelAdapter`
-([`src/modules/ingestion/adapters/azure-sentinel.adapter.ts`](../src/modules/ingestion/adapters/azure-sentinel.adapter.ts))
+([`src/modules/ingestion/adapters/azure-sentinel.adapter.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/ingestion/adapters/azure-sentinel.adapter.ts))
 is intentionally a two-line class that only reports whether `AZURE_SENTINEL_WORKSPACE` is
 set - it has no `poll()`, makes no SDK calls, and its "configured" status must never be
 read as "Sentinel is connected." Azure Activity Log fixtures are normalized through the
@@ -169,7 +169,7 @@ Both live adapters track, per-adapter (`IngestionAdapterStatus`, exposed via
 
 Pipeline-wide metrics (ingestion delay, detection evaluation/match counts, investigation
 creation/dedup counts) are tracked in
-[`src/modules/security/pipeline-metrics.ts`](../src/modules/security/pipeline-metrics.ts)
+[`src/modules/security/pipeline-metrics.ts`](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/security/pipeline-metrics.ts)
 and reflect the canonical pipeline regardless of which entry point produced the event.
 
 ## What was unified

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -3,7 +3,7 @@
 A suggested tour for reviewing this project in the dashboard, in the order the nav
 presents it (`dashboard/src/components/Layout.tsx`). Each stop says what's genuinely
 live versus replayed versus static, and where to verify that claim in the code -
-consistent with the [data provenance model](../README.md#data-provenance-live-replay-and-synthetic)
+consistent with the [data provenance model](https://github.com/jasonachkar/secure-api-gateway/blob/main/README.md#data-provenance-live-replay-and-synthetic)
 described in the README.
 
 ## Getting in

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,8 +1,8 @@
 # Operations
 
 Primary deployment target: **Azure Container Apps**, provisioned via
-[`terraform/`](../terraform). This doc covers day-to-day operation of that deployment;
-for provisioning/destroying infrastructure see [`terraform/README.md`](../terraform/README.md).
+[`terraform/`](https://github.com/jasonachkar/secure-api-gateway/tree/main/terraform). This doc covers day-to-day operation of that deployment;
+for provisioning/destroying infrastructure see [`terraform/README.md`](https://github.com/jasonachkar/secure-api-gateway/blob/main/terraform/README.md).
 
 ## Startup & health checks
 
@@ -139,7 +139,7 @@ docker compose up --build
 ```
 
 Starts the gateway (`:3000`), mock upstream service (`:4000`), Redis (`:6379`), and the
-dashboard (`:5173`) together. See the root [`README.md`](../README.md) for the full
+dashboard (`:5173`) together. See the root [`README.md`](https://github.com/jasonachkar/secure-api-gateway/blob/main/README.md) for the full
 local setup walkthrough, including running components individually without Compose.
 
 ## Backup & recovery
@@ -164,7 +164,7 @@ platform-specific assumptions, so it should also run with minimal changes on:
 - **Docker Swarm** — `docker service create` with the same image and env vars;
   configure Traefik or another LB for TLS termination.
 - **Fly.io / Railway / Render / a bare VPS** — previously-supported paths, now
-  unsupported and archived to [`legacy/deploy-configs/`](../legacy/deploy-configs)
+  unsupported and archived to [`legacy/deploy-configs/`](https://github.com/jasonachkar/secure-api-gateway/tree/main/legacy/deploy-configs)
   with notes on what's there.
 
 None of these are tested or maintained as part of this repo's CI - treat them as a

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,11 @@
+# API Reference
+
+The full OpenAPI specification for every endpoint this gateway exposes -
+authentication, admin/security control-plane routes, and the proxied upstream routes.
+
+This is rendered directly from [`openapi/openapi.yaml`](https://github.com/jasonachkar/secure-api-gateway/blob/main/openapi/openapi.yaml)
+in the repository, the same spec served live by the running gateway at `/docs` (Swagger
+UI, when `ENABLE_SWAGGER=true`). Both are built from the same source file, so they never
+drift apart.
+
+!!swagger ../openapi/openapi.yaml!!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,77 @@
+# Secure API Gateway
+
+A **production-grade API Gateway** in Fastify + TypeScript, in front of a genuine
+**multi-cloud security detection and investigation control plane**: AWS CloudTrail and
+GCP Cloud Logging feed live (Azure replay-only), gateway auth activity is monitored
+directly, everything normalizes into one canonical event schema, gets evaluated against
+documented detection rules, correlates into investigations with real evidence, and can
+trigger real response actions.
+
+This site is the reference documentation. For the live reviewer dashboard, guided
+scenarios, and a hands-on tour, see the [Reviewer Guide](DEMO_WALKTHROUGH.md) and the
+project [README](https://github.com/jasonachkar/secure-api-gateway#readme).
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+- :material-sitemap:{ .lg .middle } **Architecture**
+
+    ---
+
+    How the gateway, detection pipeline, and dashboard fit together - component
+    breakdown, data flows, and deployment topology.
+
+    [:octicons-arrow-right-24: Read the overview](ARCHITECTURE.md)
+
+- :material-shield-alert:{ .lg .middle } **Threat Model**
+
+    ---
+
+    Trust boundaries, assets, and the numbered abuse cases this system is designed
+    to detect and mitigate.
+
+    [:octicons-arrow-right-24: Read the threat model](THREAT_MODEL.md)
+
+- :material-radar:{ .lg .middle } **Detection Rules**
+
+    ---
+
+    The detection rule contract, per-rule health tracking, and every documented
+    rule from gateway credential attacks to cloud IAM privilege escalation.
+
+    [:octicons-arrow-right-24: Read the detection rules](DETECTION_RULES.md)
+
+- :material-api:{ .lg .middle } **API Reference**
+
+    ---
+
+    The full OpenAPI specification for every endpoint this gateway exposes.
+
+    [:octicons-arrow-right-24: Browse the API reference](api-reference.md)
+
+</div>
+
+## Data provenance: live, replay, and synthetic
+
+Every security event and every score in this system is tagged with where it actually
+came from, and the UI/API never blur that distinction:
+
+- **`live`** - a real event from a real source: AWS CloudTrail via CloudWatch Logs, GCP
+  Cloud Logging, or the gateway's own auth activity.
+- **`replay`** - a sanitized, real-shaped fixture pushed through the exact same
+  parse → normalize → detect → correlate pipeline as live traffic.
+- **`synthetic`** - fabricated data, off by default, used only to animate dashboard
+  charts for local visual demos, never allowed to feed detection or scoring.
+
+See [Cloud Ingestion](CLOUD_INGESTION.md) for the pipeline this provenance tagging runs
+through, and [Known Limitations](KNOWN_LIMITATIONS.md) for every place a score or
+feature is real-but-partial rather than fully live.
+
+## Honest by design
+
+Every claim in this documentation traces to a specific file in the repository - not
+aspirational bullet points. Where something genuinely isn't implemented yet, or is
+real-but-mocked, it's called out explicitly in [Known Limitations](KNOWN_LIMITATIONS.md)
+rather than glossed over. The in-app **Implementation Status** page (reviewer dashboard)
+is the single source of truth this documentation is written to match.

--- a/docs/owasp-api-top10.md
+++ b/docs/owasp-api-top10.md
@@ -11,7 +11,7 @@ Users can access objects they shouldn't by manipulating object IDs in requests.
 
 ### Our Mitigation
 
-**Implementation**: [src/modules/reports/reports.service.ts:28-48](../src/modules/reports/reports.service.ts)
+**Implementation**: [src/modules/reports/reports.service.ts:28-48](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/reports/reports.service.ts)
 
 ```typescript
 async getReport(reportId: string, userId: string, roles: string[]): Promise<Report> {
@@ -44,7 +44,7 @@ Weak or improperly implemented authentication allows attackers to compromise acc
 
 ### Our Mitigation
 
-**Implementation**: [src/modules/auth/auth.service.ts](../src/modules/auth/auth.service.ts)
+**Implementation**: [src/modules/auth/auth.service.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/auth/auth.service.ts)
 
 #### Token Rotation
 ```typescript
@@ -103,7 +103,7 @@ API returns too much data, exposing sensitive properties users shouldn't see.
 
 ### Our Mitigation
 
-**Implementation**: [src/modules/reports/reports.service.ts:56-67](../src/modules/reports/reports.service.ts)
+**Implementation**: [src/modules/reports/reports.service.ts:56-67](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/modules/reports/reports.service.ts)
 
 ```typescript
 private sanitizeReport(report: Report): Report {
@@ -136,7 +136,7 @@ API doesn't limit request rates, payload sizes, or execution time, leading to Do
 
 ### Our Mitigation
 
-**Implementation**: [src/middleware/rateLimit.ts](../src/middleware/rateLimit.ts)
+**Implementation**: [src/middleware/rateLimit.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/middleware/rateLimit.ts)
 
 #### Multi-Layer Rate Limiting
 ```typescript
@@ -186,7 +186,7 @@ Users can access admin/privileged functions by changing HTTP method or URL.
 
 ### Our Mitigation
 
-**Implementation**: [src/middleware/rbac.ts](../src/middleware/rbac.ts)
+**Implementation**: [src/middleware/rbac.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/middleware/rbac.ts)
 
 ```typescript
 // Route protection with role requirements
@@ -277,7 +277,7 @@ API fetches remote resource without validating user-supplied URL, allowing acces
 
 ### Our Mitigation
 
-**Implementation**: [src/lib/httpClient.ts](../src/lib/httpClient.ts) (`resolveAndValidateHostname`, `createPinnedDispatcher`)
+**Implementation**: [src/lib/httpClient.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/lib/httpClient.ts) (`resolveAndValidateHostname`, `createPinnedDispatcher`)
 
 ```typescript
 async function resolveAndValidateHostname(hostname: string): Promise<string[]> {
@@ -341,7 +341,7 @@ Insecure default configurations, unnecessary features enabled, verbose errors.
 
 ### Our Mitigation
 
-**Implementation**: [src/config/env.ts](../src/config/env.ts) + [src/middleware/securityHeaders.ts](../src/middleware/securityHeaders.ts)
+**Implementation**: [src/config/env.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/config/env.ts) + [src/middleware/securityHeaders.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/middleware/securityHeaders.ts)
 
 #### Config Validation
 ```typescript
@@ -439,7 +439,7 @@ Gateway blindly trusts upstream services without validation, timeouts, or error 
 
 ### Our Mitigation
 
-**Implementation**: [src/lib/httpClient.ts](../src/lib/httpClient.ts)
+**Implementation**: [src/lib/httpClient.ts](https://github.com/jasonachkar/secure-api-gateway/blob/main/src/lib/httpClient.ts)
 
 ```typescript
 export async function httpGet<T>(url: string, options: HttpClientOptions): Promise<HttpResponse<T>> {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.7.7
+mkdocs-render-swagger-plugin==0.1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,81 @@
+site_name: Secure API Gateway
+site_description: Multi-Cloud API Security Control Plane - architecture, detection rules, threat model, and API reference
+site_url: https://jasonachkar.github.io/secure-api-gateway/
+repo_url: https://github.com/jasonachkar/secure-api-gateway
+repo_name: jasonachkar/secure-api-gateway
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+  features:
+    - navigation.tabs
+    - navigation.top
+    - navigation.indexes
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Architecture:
+      - Overview: ARCHITECTURE.md
+      - Multi-Cloud Ingestion: CLOUD_INGESTION.md
+      - Concurrency Model: CONCURRENCY.md
+  - Security:
+      - Threat Model: THREAT_MODEL.md
+      - Security Controls: SECURITY_CONTROLS.md
+      - Detection Rules: DETECTION_RULES.md
+      - OWASP API Security Top 10: owasp-api-top10.md
+      - Known Limitations: KNOWN_LIMITATIONS.md
+  - Operations:
+      - Operations Guide: OPERATIONS.md
+      - Incident Response Runbooks: INCIDENT_RESPONSE.md
+      - Proxy Trust Model: PROXY_TRUST.md
+  - Reviewer Guide: DEMO_WALKTHROUGH.md
+  - API Reference: api-reference.md
+
+plugins:
+  - search
+  - render_swagger:
+      allow_arbitrary_locations: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
## Summary

Three things, requested together:

1. **Dark mode fixes + default.** Dark mode existed but was broken in several real, visible ways (verified with actual Playwright screenshots and axe accessibility scans, not just code review), and defaulted to light for the vast majority of visitors. Now defaults to dark unconditionally for first-time visitors; fixed a static always-light `theme.ts` object being used for several inline styles instead of the app's CSS custom properties, several "fixed light tint background + no matching dark text color" bugs (nearly-invisible text on Sessions/Overview/Threats/Users pages), a hardcoded white sticky header, two dangling CSS variable references, and a batch of contrast regressions that only appeared once dark became the default (colors tuned against a light background don't necessarily pass WCAG AA against a dark one). Also removed a dead link to the already-deleted `/incidents` page found along the way.

2. **404 investigation.** Every route (`/guided-scenarios`, `/investigations`, `/cloud-coverage`, even `/`) is correctly defined in `App.tsx`, matches the nav in `Layout.tsx`, and the Vercel SPA rewrite in `dashboard/vercel.json` is correct. Confirmed via real Playwright screenshots that all of these pages render fully and correctly. The actual cause: **Vercel Deployment Protection is enabled on this project and gates every route - including the homepage and a nonexistent path - behind a Vercel SSO login**, on both the preview and production deployments (confirmed via `curl -I`, all 302 to `vercel.com/sso-api`). This is a Vercel dashboard project setting, not something fixable in this repo's code. To fix: Vercel project → Settings → Deployment Protection → turn off (or scope to preview-only) for the production `.vercel.app` domain / your custom domain.

3. **MkDocs documentation site.** New GitHub Pages site built from the existing `docs/` folder with Material theme (dark/light toggle, search, Mermaid diagrams, Material icons) plus a live-rendered interactive API reference from `openapi/openapi.yaml`. Requires one manual step this PR can't do itself: repo Settings → Pages → Source: "GitHub Actions" (noted in `.github/workflows/docs.yml`'s header comment).

## Test plan

- [x] Dashboard `tsc --noEmit` and `npm run build` both clean
- [x] Full Playwright + axe accessibility suite: 14/14 accessibility checks passing (zero serious/critical violations) across every nav page in dark mode; 17/18 e2e tests passing (18th is a pre-existing, documented local-environment flake unrelated to this change)
- [x] Verified dark mode visually via real screenshots across Login, Landing, Overview, Guided Scenarios, Investigations, Cloud Coverage, Compliance, Audit Logs, Sessions, About - and confirmed light mode still works correctly after the default change
- [x] `mkdocs build --strict` passes with zero warnings; verified locally via `mkdocs serve` that the Swagger UI, Mermaid diagrams, and icons all actually render (not just that the build succeeds)
- [x] Backend test suite unaffected (no backend code changed): 257/258 passing (1 pre-existing, documented local flake, same root cause as the e2e one, unrelated)
- [ ] CI will run fresh on this PR - watching for green before considering this done

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>