### PR TITLE
Surface real backend error messages across the dashboard

### DIFF
--- a/dashboard/src/api/errors.ts
+++ b/dashboard/src/api/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Extracts a human-readable message from an API error.
+ * Axios errors default to a generic "Request failed with status code NNN"
+ * (err.message) even when the backend sent a real error body - prefer that
+ * body's message so the UI shows why a request actually failed.
+ */
+export function getErrorMessage(err: any, fallback: string): string {
+  return (
+    err?.response?.data?.error?.message ||
+    err?.response?.data?.message ||
+    err?.message ||
+    fallback
+  );
+}

--- a/dashboard/src/pages/AuditLogs.tsx
+++ b/dashboard/src/pages/AuditLogs.tsx
@@ -13,6 +13,7 @@ import { SectionHeader } from '../components/SectionHeader';
 import { Table, TableHeader, TableBody, TableRow, TableHeaderCell, TableCell } from '../components/Table';
 import { AuditReportExport } from '../components/AuditReportExport';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { AdminAuditLogEntry } from '../types';
 import { format } from 'date-fns';
 
@@ -83,7 +84,7 @@ export function AuditLogs() {
       const end = start + filters.pageSize;
       setLogs(data.slice(start, end));
     } catch (err: any) {
-      setError(err.message || 'Failed to fetch audit logs');
+      setError(getErrorMessage(err, 'Failed to fetch audit logs'));
       setAllLogs([]);
     } finally {
       setLoading(false);

--- a/dashboard/src/pages/CloudCoverage.tsx
+++ b/dashboard/src/pages/CloudCoverage.tsx
@@ -10,6 +10,7 @@ import { Badge } from '../components/Badge';
 import { SectionHeader } from '../components/SectionHeader';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { PipelineMetricsSnapshot, OperationalHealth, CloudProvider } from '../types';
 
 const HEALTH_VARIANT: Record<OperationalHealth, 'success' | 'warning' | 'error' | 'info' | 'neutral'> = {
@@ -47,7 +48,7 @@ export function CloudCoverage() {
         const data = await adminApi.getPipelineMetrics();
         if (!cancelled) setSnapshot(data);
       } catch (err: any) {
-        if (!cancelled) setError(err.message || 'Failed to load pipeline metrics');
+        if (!cancelled) setError(getErrorMessage(err, 'Failed to load pipeline metrics'));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/dashboard/src/pages/Compliance.tsx
+++ b/dashboard/src/pages/Compliance.tsx
@@ -13,6 +13,7 @@ import { Badge } from '../components/Badge';
 import { Card } from '../components/Card';
 import { SectionHeader } from '../components/SectionHeader';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import { NIST_EVIDENCE, OWASP_EVIDENCE, PCI_EVIDENCE, githubUrl, type EvidenceEntry } from '../data/complianceEvidence';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import type { SecurityPosture, ComplianceMetrics, ComplianceAssessmentBasis } from '../types';
@@ -162,7 +163,7 @@ export function Compliance() {
       setMetrics(metricsResponse);
       setError('');
     } catch (err: any) {
-      setError(err.message || 'Failed to fetch compliance data');
+      setError(getErrorMessage(err, 'Failed to fetch compliance data'));
       setPosture(null);
       setMetrics(null);
     } finally {

--- a/dashboard/src/pages/GuidedScenarios.tsx
+++ b/dashboard/src/pages/GuidedScenarios.tsx
@@ -16,6 +16,7 @@ import { SectionHeader } from '../components/SectionHeader';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { useToast } from '../contexts/ToastContext';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { ScenarioDefinition, ScenarioRunResult, ScenarioId } from '../types';
 
 const PROVENANCE_VARIANT: Record<string, 'success' | 'info' | 'neutral'> = {
@@ -46,7 +47,7 @@ export function GuidedScenarios() {
         const data = await adminApi.getScenarios();
         if (!cancelled) setScenarios(data);
       } catch (err: any) {
-        if (!cancelled) setError(err.message || 'Failed to load scenarios');
+        if (!cancelled) setError(getErrorMessage(err, 'Failed to load scenarios'));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -63,7 +64,7 @@ export function GuidedScenarios() {
       setResults((prev) => ({ ...prev, [id]: result }));
       showToast(`Scenario "${id}" completed`, 'success');
     } catch (err: any) {
-      showToast(err.response?.data?.error?.message || err.message || 'Scenario run failed', 'error');
+      showToast(getErrorMessage(err, 'Scenario run failed'), 'error');
     } finally {
       setRunning(null);
     }
@@ -74,7 +75,7 @@ export function GuidedScenarios() {
       await adminApi.resetGatewayScenario();
       showToast('Gateway scenario reset (demo IP unblocked, lockout cleared)', 'success');
     } catch (err: any) {
-      showToast(err.message || 'Reset failed', 'error');
+      showToast(getErrorMessage(err, 'Reset failed'), 'error');
     }
   };
 

--- a/dashboard/src/pages/ImplementationStatus.tsx
+++ b/dashboard/src/pages/ImplementationStatus.tsx
@@ -12,6 +12,7 @@ import { Badge } from '../components/Badge';
 import { SectionHeader } from '../components/SectionHeader';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { CapabilityDefinition, CapabilityStatus, CapabilityCategory } from '../types';
 
 const STATUS_META: Record<CapabilityStatus, { label: string; variant: 'success' | 'warning' | 'info' | 'neutral'; icon: typeof CheckCircle2 }> = {
@@ -55,7 +56,7 @@ export function ImplementationStatus() {
         setCapabilities(summary.capabilities);
         setCounts(summary.counts);
       } catch (err: any) {
-        if (!cancelled) setError(err.message || 'Failed to load capability registry');
+        if (!cancelled) setError(getErrorMessage(err, 'Failed to load capability registry'));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/dashboard/src/pages/Investigations.tsx
+++ b/dashboard/src/pages/Investigations.tsx
@@ -17,6 +17,7 @@ import { SectionHeader } from '../components/SectionHeader';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { useToast } from '../contexts/ToastContext';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { SecurityInvestigation, NormalizedSecurityEvent, DetectionResult, SecuritySeverity, InvestigationStatus } from '../types';
 
 const SEVERITY_VARIANT: Record<SecuritySeverity, 'success' | 'warning' | 'error' | 'info' | 'neutral'> = {
@@ -59,7 +60,7 @@ export function Investigations() {
       const data = await adminApi.getInvestigations({ limit: 100 });
       setInvestigations(data);
     } catch (err: any) {
-      setError(err.message || 'Failed to load investigations');
+      setError(getErrorMessage(err, 'Failed to load investigations'));
     } finally {
       setLoading(false);
     }
@@ -77,7 +78,7 @@ export function Investigations() {
       setEvents(events);
       setDetections(detections);
     } catch (err: any) {
-      showToast(err.message || 'Failed to load investigation detail', 'error');
+      showToast(getErrorMessage(err, 'Failed to load investigation detail'), 'error');
     } finally {
       setDetailLoading(false);
     }
@@ -101,7 +102,7 @@ export function Investigations() {
       URL.revokeObjectURL(url);
       showToast('Evidence package downloaded', 'success');
     } catch (err: any) {
-      showToast(err.message || 'Evidence export failed', 'error');
+      showToast(getErrorMessage(err, 'Evidence export failed'), 'error');
     }
   };
 

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { KeyRound, ShieldCheck, Eye } from 'lucide-react';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '../components/Button';
 import { ThemeToggle } from '../components/ThemeToggle';
@@ -60,13 +61,7 @@ export function Login() {
       login(response.accessToken);
       navigate('/', { replace: true });
     } catch (err: any) {
-      const errorMessage =
-        err.response?.data?.error?.message ||
-        err.response?.data?.message ||
-        err.message ||
-        'Login failed. Please check your credentials.';
-
-      setError(errorMessage);
+      setError(getErrorMessage(err, 'Login failed. Please check your credentials.'));
     } finally {
       setLoading(false);
     }
@@ -80,7 +75,7 @@ export function Login() {
       login(response.accessToken);
       navigate('/', { replace: true });
     } catch (err: any) {
-      setError(err.message || 'Could not start the reviewer demo session.');
+      setError(getErrorMessage(err, 'Could not start the reviewer demo session.'));
     } finally {
       setDemoLoading(false);
     }

--- a/dashboard/src/pages/Sessions.tsx
+++ b/dashboard/src/pages/Sessions.tsx
@@ -18,6 +18,7 @@ import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { useCountdown } from '../hooks/useCountdown';
 import { useToast } from '../contexts/ToastContext';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import { useAuth } from '../contexts/AuthContext';
 import type { SessionInfo } from '../types';
 
@@ -42,7 +43,7 @@ export function Sessions() {
       setSessions(data);
       setError('');
     } catch (err: any) {
-      setError(err.message || 'Failed to fetch sessions');
+      setError(getErrorMessage(err, 'Failed to fetch sessions'));
     } finally {
       setLoading(false);
     }
@@ -95,7 +96,7 @@ export function Sessions() {
     try {
       await performRevoke(jti);
     } catch (err: any) {
-      showToast('Failed to revoke session: ' + err.message, 'error');
+      showToast('Failed to revoke session: ' + getErrorMessage(err, 'unknown error'), 'error');
     }
   };
 
@@ -116,7 +117,7 @@ export function Sessions() {
       await fetchSessions();
       showToast(`Revoked all ${targets.length} session(s) for ${bulkRevokeUser}`, 'success');
     } catch (err: any) {
-      showToast('Failed to revoke all sessions: ' + err.message, 'error');
+      showToast('Failed to revoke all sessions: ' + getErrorMessage(err, 'unknown error'), 'error');
     }
   };
 

--- a/dashboard/src/pages/Threats.tsx
+++ b/dashboard/src/pages/Threats.tsx
@@ -16,6 +16,7 @@ import { WorldMapHeatmap } from '../components/WorldMapHeatmap';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { useToast } from '../contexts/ToastContext';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { IPThreatInfo, ThreatStatistics, AttackPattern, ThreatLevel } from '../types';
 
 const threatLevelBadgeClass: Record<ThreatLevel, string> = {
@@ -58,7 +59,7 @@ export function Threats() {
       setPatterns(patternsData);
       setError('');
     } catch (err: any) {
-      setError(err.message || 'Failed to fetch threat data');
+      setError(getErrorMessage(err, 'Failed to fetch threat data'));
     } finally {
       setLoading(false);
     }
@@ -74,7 +75,7 @@ export function Threats() {
       await fetchData();
       showToast(`${ip} has been blocked`, 'success');
     } catch (err: any) {
-      showToast('Failed to block IP: ' + err.message, 'error');
+      showToast('Failed to block IP: ' + getErrorMessage(err, 'unknown error'), 'error');
     }
   };
 
@@ -88,7 +89,7 @@ export function Threats() {
       await fetchData();
       showToast(`${ip} has been unblocked`, 'success');
     } catch (err: any) {
-      showToast('Failed to unblock IP: ' + err.message, 'error');
+      showToast('Failed to unblock IP: ' + getErrorMessage(err, 'unknown error'), 'error');
     }
   };
 

--- a/dashboard/src/pages/Users.tsx
+++ b/dashboard/src/pages/Users.tsx
@@ -13,6 +13,7 @@ import { ConfirmModal } from '../components/ConfirmModal';
 import { PageLoadingSkeleton } from '../components/PageLoadingSkeleton';
 import { useToast } from '../contexts/ToastContext';
 import { adminApi } from '../api/admin';
+import { getErrorMessage } from '../api/errors';
 import type { UserInfo } from '../types';
 
 export function Users() {
@@ -32,7 +33,7 @@ export function Users() {
       setUsers(data);
       setError('');
     } catch (err: any) {
-      setError(err.message || 'Failed to fetch users');
+      setError(getErrorMessage(err, 'Failed to fetch users'));
     } finally {
       setLoading(false);
     }
@@ -48,7 +49,7 @@ export function Users() {
       await fetchUsers();
       showToast(`${username}'s account has been unlocked`, 'success');
     } catch (err: any) {
-      showToast('Failed to unlock user: ' + err.message, 'error');
+      showToast('Failed to unlock user: ' + getErrorMessage(err, 'unknown error'), 'error');
     }
   };
 


### PR DESCRIPTION
## Summary

Follow-up to #17. That PR fixed the SPA 404-on-refresh (missing `staticwebapp.config.json` for Azure Static Web Apps) and added a cold-start hint to the login page. This PR addresses the next symptom reported: many dashboard pages (Implementation Status, Investigations, Cloud Coverage, Audit Logs, Compliance, Sessions, Threats, Users, Guided Scenarios) were showing a bare `Request failed with status code 404` instead of a useful error.

- Every one of those pages caught API errors with `err.message`, which for an axios error is *always* the generic `"Request failed with status code NNN"` — it never reads the backend's actual error body (`{ error: { message } }`), so a 404, 403, or 500 all rendered identically and gave no signal about what actually failed.
- Added `dashboard/src/api/errors.ts` (`getErrorMessage`) which checks `response.data.error.message`, then `response.data.message`, then falls back to `err.message`, and wired it into every page listed above plus `Login.tsx` (which had its own inline copy of the same logic).

## Root cause of the underlying 404s (not fixable in this PR)

The generic-message bug above was masking the real problem: the requests I traced (e.g. `GET /admin/security/capabilities`) are genuinely 404ing against the live backend, and the route exists in `src/modules/security/security.routes.ts` on `main`. This isn't a code bug — it's a deployment gap:

- `.github/workflows/deploy.yml` (the only thing that pushes a new image to the backend Container App) is `workflow_dispatch`-only by design, and Actions history shows it has **never actually executed a job** across the last 30 pushes to `main` (each push produces a 0-job "failure" placeholder since the workflow simply doesn't trigger on `push`).
- Terraform's Container App module boots a placeholder image at first `apply`; only a real deploy replaces it with the current gateway build.

Net effect: the live backend is almost certainly running an older image that predates the `/admin/security/*` control-plane routes, which is why some pages 404 and others (Sessions, Users, Audit Logs, login itself) work fine.

**Action needed from a maintainer**: this session's GitHub token doesn't have `actions:write`, so I couldn't dispatch the workflow myself (got a 403 `Resource not accessible by integration`). To finish resolving the 404s, run:

```bash
gh workflow run deploy.yml --ref main
```

or trigger it from the Actions tab (Deploy to Azure → Run workflow, ref `main`) — provided the `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`, `ACR_LOGIN_SERVER`, `RESOURCE_GROUP`, and `CONTAINER_APP_NAME` secrets are already set (Settings → Secrets and variables → Actions).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [ ] Manually verify Implementation Status / Investigations / Cloud Coverage load without a 404 after the backend is redeployed


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4X7apScAh5LaJhVzmZe7C)_