### PR TITLE
Fix API Documentation link; confirm Cloud Coverage/Guided Scenarios/Investigations are fully implemented

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -32,7 +32,11 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+// Swagger UI (${API_URL}/docs) is deliberately disabled in production (see
+// ENABLE_SWAGGER in src/config/env.ts) so the interactive API schema isn't public
+// by default. The MkDocs site (mkdocs.yml, deployed by .github/workflows/docs.yml)
+// is the production-appropriate API reference instead.
+const DOCS_URL = 'https://jasonachkar.github.io/secure-api-gateway/';
 
 const primaryNavItems = [
   { path: '/', label: 'Overview', icon: LayoutGrid },
@@ -153,7 +157,7 @@ export function Layout({ children }: LayoutProps) {
                 </NavLink>
               ))}
               <a
-                href={`${API_URL}/docs`}
+                href={DOCS_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="nav-link nav-link--inactive"


### PR DESCRIPTION
## Summary

Follow-up to #17/#18. Reported symptom: "route not found" on Cloud Coverage, Guided Scenarios, Investigations, and API Documentation.

### API Documentation — real bug, fixed here

The sidebar's "API Documentation" link went to `${API_URL}/docs` (the backend's Swagger UI). Swagger is deliberately disabled in production by default (`enableSwagger = ENABLE_SWAGGER ?? !isProduction` in `src/config/env.ts`) so the interactive API schema isn't public — so this link 404'd on every production deploy, not just this one.

Changed `dashboard/src/components/Layout.tsx` to point at the MkDocs site (`https://jasonachkar.github.io/secure-api-gateway/`, built from `mkdocs.yml` by `.github/workflows/docs.yml`) instead — the production-appropriate API/architecture reference, and it keeps Swagger closed.

**Action needed from a maintainer**: that MkDocs site isn't live yet. Its one deploy attempt (`docs.yml` run [30498639506](https://github.com/jasonachkar/secure-api-gateway/actions/runs/30498639506)) failed with:
```
Error: Failed to create deployment (status: 404)... Ensure GitHub Pages has been enabled: https://github.com/jasonachkar/secure-api-gateway/settings/pages
```
Repo **Settings → Pages → Source** needs to be switched to **"GitHub Actions"** (currently unset) — I don't have a tool that can change that setting. Once it's flipped, either push any change under `docs/**` or manually run `docs.yml` (Actions → Docs (MkDocs → GitHub Pages) → Run workflow) to publish it.

### Cloud Coverage, Guided Scenarios, Investigations — verified fully implemented, no code change needed

Checked before assuming these needed building:
- `src/modules/scenarios/scenario.service.ts` (403 lines), `src/modules/investigations/investigation.service.ts` (432 lines) + `correlation.ts` (73 lines), `src/modules/security/pipeline-metrics.ts` (220 lines) — real logic, no TODOs/stubs.
- Backed by real tests: `test/scenarios.integration.test.ts`, `test/investigations.unit.test.ts`, `test/pipeline-metrics-latency.unit.test.ts`.
- The app's own honesty ledger (`src/modules/security/capability-registry.ts`, which powers the Implementation Status page) lists `investigations` and `guided-scenarios` as `status: 'implemented', provenance: 'live'`.

Their 404s are the same root cause as #17/#18: the backend Container App still hasn't been redeployed with the current `main` branch (`deploy.yml` remains untriggered — 0 `workflow_dispatch` runs as of this PR). No code fix applies here; running the deploy (`gh workflow run deploy.yml --ref main` or Actions → Deploy to Azure → Run workflow) resolves it.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [ ] After GitHub Pages is enabled and `docs.yml` runs successfully, manually verify the "API Documentation" sidebar link opens the live MkDocs site
- [ ] After the backend is redeployed, manually verify Cloud Coverage / Guided Scenarios / Investigations load without a 404


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4X7apScAh5LaJhVzmZe7C)_