### PR TITLE
Fix invalid workflow_dispatch input default blocking every deploy.yml run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,8 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to build and deploy'
+        description: 'Image tag to build and deploy (defaults to the triggering commit SHA if left blank)'
         required: false
-        default: ${{ github.sha }}
 
 permissions:
   id-token: write # required for OIDC federated login
@@ -67,7 +66,7 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ secrets.ACR_LOGIN_SERVER }}/secure-api-gateway:${{ inputs.image_tag }}
+            ${{ secrets.ACR_LOGIN_SERVER }}/secure-api-gateway:${{ inputs.image_tag || github.sha }}
             ${{ secrets.ACR_LOGIN_SERVER }}/secure-api-gateway:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -77,7 +76,7 @@ jobs:
           az containerapp update \
             --name "${{ secrets.CONTAINER_APP_NAME }}" \
             --resource-group "${{ secrets.RESOURCE_GROUP }}" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/secure-api-gateway:${{ inputs.image_tag }}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/secure-api-gateway:${{ inputs.image_tag || github.sha }}"
 
       - name: Verify health
         run: |


### PR DESCRIPTION
## Summary

Root cause of the Cloud Coverage / Guided Scenarios / Implementation Status 404s finally found: `deploy.yml` has **never once successfully run** because it fails to parse. GitHub rejects it before any job starts:

```
Invalid workflow file: .github/workflows/deploy.yml#L1
(Line: 39, Col: 18): Unrecognized named-value: 'github'.
Located at position 1 within expression: github.sha
```

`on.workflow_dispatch.inputs.image_tag.default: ${{ github.sha }}` is invalid syntax — the `github` context isn't available while evaluating `on:` trigger definitions (that block is parsed before any job/step context exists), only inside jobs/steps. This is why every dispatch attempt (manual or the phantom `push`-triggered entries visible in Actions history) has failed immediately with 0 jobs run, going back to when this workflow was added.

## Fix

- Removed the invalid `default: ${{ github.sha }}` from the `image_tag` input.
- Both call sites that use `inputs.image_tag` (the Docker tag list and the `az containerapp update --image` argument) now use `${{ inputs.image_tag || github.sha }}` instead — valid because those are inside job steps, where the `github` context is available. Leaving the input blank at dispatch time still resolves to the triggering commit's SHA, same behavior originally intended.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — valid YAML
- [ ] Manually trigger `Deploy to Azure` after merge and confirm it now parses and runs (requires `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`, `ACR_LOGIN_SERVER`, `RESOURCE_GROUP`, `CONTAINER_APP_NAME` secrets to already be set)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4X7apScAh5LaJhVzmZe7C)_