### PR TITLE
Fix deploy.yml GHA cache export failure (missing setup-buildx-action)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,13 @@ jobs:
       - name: ACR login
         run: az acr login --name "$(cut -d. -f1 <<< '${{ secrets.ACR_LOGIN_SERVER }}')"
 
+      # The default `docker` buildx driver can't export to the GHA cache backend
+      # (type=gha below) - only the `docker-container` driver can. Without this step,
+      # build-push-action falls back to the default driver and fails with
+      # "Cache export is not supported for the docker driver."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

Follow-up to #20. After fixing the OIDC federated-credential subject (added an `environment:production`-scoped credential alongside the branch one), the deploy got past Azure login and ACR login, then failed at the build step:

```
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

`docker/build-push-action@v6` was configured with `cache-to: type=gha,mode=max`, but the workflow never set up a buildx builder — so it fell back to the default `docker` driver, which can't export to the GHA cache backend. Only the `docker-container` driver supports it.

## Fix

Add a `docker/setup-buildx-action@v3` step between "ACR login" and "Build and push image", so buildx uses a driver that supports `type=gha` cache export. `docker.yml` (the separate CI build/scan workflow) doesn't need this since it uses plain `docker build`, not buildx with GHA caching.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — valid YAML
- [ ] Manually re-trigger `Deploy to Azure` after merge and confirm the build step now succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4X7apScAh5LaJhVzmZe7C)_